### PR TITLE
feat(v1.0.22): 正方教务Parser + URL直接登录导入

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.lingion.sleepy.debug"
         minSdk = 24
         targetSdk = 35
-        versionCode = 21
-        versionName = "1.0.21"
+        versionCode = 22
+        versionName = "1.0.22"
         vectorDrawables { useSupportLibrary = true }
         // Explicit locales bundled into the APK. Default resources in values/
         // (zh-CN content) are always kept. We list zh-rCN explicitly so that

--- a/app/src/main/java/com/lingion/sleepy/data/jw/JwImportViewModel.kt
+++ b/app/src/main/java/com/lingion/sleepy/data/jw/JwImportViewModel.kt
@@ -83,21 +83,60 @@ class JwImportViewModel(application: Application) : AndroidViewModel(application
      * 解析 HTML 源码，返回课程列表（不入库）
      */
     suspend fun parseHtml(html: String, protocolType: String): List<JwCourse> = withContext(Dispatchers.IO) {
+        if (protocolType.isBlank()) {
+            // 未知协议（URL 直接登录）：尝试所有 parser，取课程数最多的结果
+            return@withContext tryAllParsers(html)
+        }
         val parser: JwParser = when (protocolType) {
             JwProtocol.TYPE_QZ -> JwQzParser(html)
             JwProtocol.TYPE_QZ_CRAZY -> JwQzCrazyParser(html)
-            JwProtocol.TYPE_QZ_BR -> JwQzParser(html)  // 简化：先 fallback 到 QzParser
+            JwProtocol.TYPE_QZ_BR -> JwQzParser(html)
             JwProtocol.TYPE_QZ_WITH_NODE -> JwQzParser(html)
             JwProtocol.TYPE_QZ_OLD -> JwQzParser(html)
             JwProtocol.TYPE_URP -> JwUrpParser(html)
             JwProtocol.TYPE_URP_NEW -> JwNewUrpParser(html)
             JwProtocol.TYPE_WISEDU -> JwWiseduParser(html)
-            JwProtocol.TYPE_ZF -> JwQzParser(html)  // ZF 先 fallback，后续补 JwNewZFParser
-            JwProtocol.TYPE_ZF_NEW -> JwQzParser(html)
-            JwProtocol.TYPE_ZF_1 -> JwQzParser(html)
+            JwProtocol.TYPE_ZF -> JwNewZfParser(html)
+            JwProtocol.TYPE_ZF_NEW -> JwNewZfParser(html)
+            JwProtocol.TYPE_ZF_1 -> JwNewZfParser(html)
             else -> throw IllegalArgumentException("协议 $protocolType 暂不支持")
         }
         parser.generateCourseList()
+    }
+
+    /** 未知协议时，尝试所有 parser，取课程数最多的结果 */
+    private fun tryAllParsers(html: String): List<JwCourse> {
+        val candidates = listOf(
+            JwWiseduParser(html),
+            JwNewUrpParser(html),
+            JwNewZfParser(html),
+            JwQzParser(html),
+            JwQzCrazyParser(html),
+            JwUrpParser(html)
+        )
+        var best = emptyList<JwCourse>()
+        for (p in candidates) {
+            try {
+                val result = p.generateCourseList()
+                if (result.size > best.size) best = result
+            } catch (e: Exception) { continue }
+        }
+        return best
+    }
+
+    /**
+     * 从 URL 自动检测教务协议类型
+     */
+    fun detectProtocolFromUrl(url: String): String? {
+        val u = url.lowercase()
+        return when {
+            u.contains("jwapp/sys/") || u.contains("/jwapp/") -> JwProtocol.TYPE_WISEDU
+            u.contains("jwglxt") || u.contains("/xtgl/") -> JwProtocol.TYPE_ZF_NEW
+            u.contains("/jwtottxuxsysb/") -> JwProtocol.TYPE_ZF_NEW
+            u.contains("qz") || u.contains("strongdesk") -> JwProtocol.TYPE_QZ
+            u.contains("urp") -> JwProtocol.TYPE_URP_NEW
+            else -> null
+        }
     }
 
     /**

--- a/app/src/main/java/com/lingion/sleepy/data/jw/JwNewZfParser.kt
+++ b/app/src/main/java/com/lingion/sleepy/data/jw/JwNewZfParser.kt
@@ -1,0 +1,316 @@
+package com.lingion.sleepy.data.jw
+
+import org.json.JSONArray
+import org.jsoup.Jsoup
+
+/**
+ * 正方教务（新版）课表解析器。
+ *
+ * 适配 zf_new 协议学校（52所）。正方新版教务（基于 SpringMVC / Vue）课表页：
+ *   1. 数据可能嵌入在 `<script>` 标签 JSON 中（API 响应直出 / Vue data）
+ *   2. 或渲染为标准 HTML 表格（`<div class="kbcontent">` + `<font title="...">`）
+ *
+ * 解析策略：JSON 优先 → HTML 表格兜底（兼容 QZ 结构 + zf_new kbgrid 结构）。
+ *
+ * 参考：
+ *   - dIT8Zv/WakeupSchedule_BUPT NewZfParser.kt
+ *   - nKEatonxuan/CourseAdapter 正方协议适配
+ */
+class JwNewZfParser(source: String) : JwParser(source) {
+
+    override fun generateCourseList(): List<JwCourse> {
+        // 1. 尝试从页面提取嵌入的 JSON
+        parseEmbeddedJson().takeIf { it.isNotEmpty() }?.let { return it }
+
+        // 2. HTML 表格解析
+        return parseHtmlTable()
+    }
+
+    // ─── JSON 提取 ────────────────────────────────────────────
+
+    /**
+     * 从 HTML 中提取正方新版课表 JSON。
+     *
+     * 常见嵌入方式：
+     *   - `<script>var kbxx = [...];</script>`
+     *   - `<script>window.__INITIAL_STATE__ = {…"kbxx":[…]…};</script>`
+     *   - API 响应直接嵌入（纯 JSON 页面 `{"kbxx":[…]}`）
+     *   - `var xskbcx_json = {"tmp_list":[…]};`（部分版本）
+     */
+    private fun parseEmbeddedJson(): List<JwCourse> {
+        // 标记关键字 → 多种正方版本的字段名
+        val markers = listOf("\"kbxx\"", "\"tmp_list\"", "\"xskbcx\"", "xskbcx_json")
+
+        for (marker in markers) {
+            val idx = source.indexOf(marker)
+            if (idx < 0) continue
+
+            // 找到 marker 后的数组开始位置 '['
+            var arrStart = idx + marker.length
+            while (arrStart < source.length && source[arrStart] !in "[{") arrStart++
+            if (arrStart >= source.length) continue
+
+            val jsonStr = extractBalanced(source, arrStart) ?: continue
+            val courses = parseCourseJsonArray(jsonStr)
+            if (courses.isNotEmpty()) return courses
+        }
+
+        // 尝试纯 JSON 页面（API 响应被 WebView 直接渲染）
+        val trimmed = source.trim()
+        if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+            val courses = parseCourseJsonArray(trimmed)
+            if (courses.isNotEmpty()) return courses
+        }
+
+        return emptyList()
+    }
+
+    /** 从 start 位置提取配对的 JSON 数组/对象（括号匹配） */
+    private fun extractBalanced(s: String, start: Int): String? {
+        if (start >= s.length) return null
+        val open = s[start]
+        val close = when (open) {
+            '[' -> ']'
+            '{' -> '}'
+            else -> return null
+        }
+        var depth = 0
+        var inStr = false
+        var esc = false
+        for (i in start until s.length) {
+            val c = s[i]
+            if (esc) { esc = false; continue }
+            if (c == '\\') { esc = true; continue }
+            if (c == '"') { inStr = !inStr; continue }
+            if (inStr) continue
+            when (c) {
+                open -> depth++
+                close -> { depth--; if (depth == 0) return s.substring(start, i + 1) }
+            }
+        }
+        return null
+    }
+
+    private fun parseCourseJsonArray(jsonStr: String): List<JwCourse> {
+        val result = mutableListOf<JwCourse>()
+        try {
+            // 可能是数组直接开始，也可能包在对象里
+            val arr: JSONArray = when (jsonStr[0]) {
+                '[' -> JSONArray(jsonStr)
+                '{' -> {
+                    val obj = org.json.JSONObject(jsonStr)
+                    // 找第一个 JSONArray 属性
+                    var found: JSONArray? = null
+                    for (key in obj.keys()) {
+                        val v = obj.optJSONArray(key)
+                        if (v != null && v.length() > 0) { found = v; break }
+                    }
+                    found ?: return emptyList()
+                }
+                else -> return emptyList()
+            }
+
+            for (i in 0 until arr.length()) {
+                val o = arr.optJSONObject(i) ?: continue
+
+                // 课程名（正方多版本字段名）
+                val name = firstStr(o, "kcmc", "kcm", "kc_mc", "courseName", "rlkcmc", "jxbmc")
+                if (name.isBlank()) continue
+
+                val teacher = firstStr(o, "jsxm", "jsmc", "teacher", "attendClassTeacher", "skjs")
+                val room = firstStr(o, "jasmc", "jsmc", "classroomName", "jxlh", "jasdm")
+
+                // 星期
+                val day = firstInt(o, "kcxq", "xq", "xqj", "classDay", "skxq") ?: continue
+
+                // 节次
+                val startNode = firstInt(o, "ksjcsd", "ksjc", "jc", "classSessions", "ksjcd")
+                    ?: firstInt(o, "ksjc") ?: continue
+                val endNode = firstInt(o, "jsjcsd", "jsjc", "jsjssd", "continuingSession")
+                    ?.let { if (it < startNode) startNode else it }
+                    ?: (startNode + 1)
+
+                // 周次
+                val zcStr = firstStr(o, "zcd", "kkzc", "zc", "classWeek", "skzc")
+                val ranges = parseWeekStr(zcStr)
+
+                for (r in ranges) {
+                    result += JwCourse(
+                        name = name,
+                        room = room,
+                        teacher = teacher,
+                        day = day.coerceIn(1, 7),
+                        startNode = startNode.coerceAtLeast(1),
+                        endNode = endNode.coerceAtLeast(startNode),
+                        startWeek = r.first,
+                        endWeek = r.second,
+                        type = r.third
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            // JSON 解析失败，静默
+        }
+        return result
+    }
+
+    private fun firstStr(o: org.json.JSONObject, vararg keys: String): String {
+        for (k in keys) {
+            val v = o.optString(k, "").trim()
+            if (v.isNotBlank()) return v
+        }
+        return ""
+    }
+
+    private fun firstInt(o: org.json.JSONObject, vararg keys: String): Int? {
+        for (k in keys) {
+            val v = o.optString(k, "").trim()
+            if (v.isNotBlank()) return v.toIntOrNull()
+        }
+        return null
+    }
+
+    /** 周次字符串 → (start, end, type) 范围列表 */
+    private fun parseWeekStr(s: String): List<Triple<Int, Int, Int>> {
+        if (s.isBlank()) return listOf(Triple(1, 20, 0))
+        val result = mutableListOf<Triple<Int, Int, Int>>()
+
+        // bitmap 模式：11111111111100000（每位 = 第 N 周）
+        if (s.length >= 10 && s.all { it == '0' || it == '1' }) {
+            val weeks = s.mapIndexedNotNull { i, c -> if (c == '1') i + 1 else null }
+            return bitsToRanges(weeks)
+        }
+
+        // 范围/列表模式："1-16" / "1-16周" / "1-16周(单)" / "1,3,5,7"
+        s.split(",", "，", ";", "；").forEach { part ->
+            val cleaned = part.replace("周", "").replace("(", "").replace(")", "").trim()
+            val type = when {
+                part.contains("单") -> 1
+                part.contains("双") -> 2
+                else -> 0
+            }
+            if (cleaned.contains("-")) {
+                val parts = cleaned.split("-")
+                val start = parts.getOrNull(0)?.filter { it.isDigit() }?.toIntOrNull() ?: 1
+                val end = parts.getOrNull(1)?.filter { it.isDigit() }?.toIntOrNull() ?: start
+                result += Triple(start, end, type)
+            } else {
+                val v = cleaned.filter { it.isDigit() }.toIntOrNull() ?: return@forEach
+                result += Triple(v, v, type)
+            }
+        }
+        return if (result.isEmpty()) listOf(Triple(1, 20, 0)) else result
+    }
+
+    private fun bitsToRanges(weeks: List<Int>): List<Triple<Int, Int, Int>> {
+        if (weeks.isEmpty()) return emptyList()
+        val result = mutableListOf<Triple<Int, Int, Int>>()
+        var i = 0
+        while (i < weeks.size) {
+            val start = weeks[i]
+            var end = start
+            if (i + 1 < weeks.size && weeks[i + 1] - start == 2) {
+                // 单/双周模式
+                end = weeks[i + 1]
+                var k = i + 1
+                while (k + 1 < weeks.size && weeks[k + 1] - weeks[k] == 2) { k++; end = weeks[k] }
+                val type = if (start % 2 == 1) 1 else 2
+                result += Triple(start, end, type)
+                i = k + 1
+            } else if (i + 1 < weeks.size && weeks[i + 1] - start == 1) {
+                // 连续周
+                end = weeks[i + 1]
+                var k = i + 1
+                while (k + 1 < weeks.size && weeks[k + 1] - weeks[k] == 1) { k++; end = weeks[k] }
+                result += Triple(start, end, 0)
+                i = k + 1
+            } else {
+                result += Triple(start, end, 0)
+                i++
+            }
+        }
+        return result
+    }
+
+    // ─── HTML 表格解析（兜底） ─────────────────────────────────
+
+    /**
+     * 正方新版渲染后的 HTML 与强智类似但容器 ID 可能不同。
+     * 尝试 "kbtable" / "kbgrid" / class 选择器。
+     */
+    private fun parseHtmlTable(): List<JwCourse> {
+        val doc = Jsoup.parse(source)
+
+        // 多种容器选择器
+        val container = doc.getElementById("kbtable")
+            ?: doc.getElementById("kbgrid")
+            ?: doc.selectFirst("table.el-table__body")
+            ?: doc.selectFirst(".kbcapi-table")
+            ?: doc.selectFirst("[id*=kb]")
+            ?: return parseHtmlTableFromQz()  // 完全 fallback 到 QZ 逻辑
+
+        val result = mutableListOf<JwCourse>()
+        val trs = container.getElementsByTag("tr")
+        var nodeCount = 0
+
+        for (tr in trs) {
+            val tds = tr.getElementsByTag("td")
+            if (tds.isEmpty()) continue
+            nodeCount++
+
+            var day = 0
+            for (td in tds) {
+                day++
+                val cells = td.getElementsByClass("kbcontent")
+                if (cells.isEmpty()) continue
+
+                for (cell in cells) {
+                    val html = cell.html()
+                    if (html.isBlank()) continue
+                    // 同格多门课用 "-----" 分隔（与 QZ 一致）
+                    val parts = html.split("-----")
+                    for (part in parts) {
+                        parseCell(part.trim(), day, nodeCount)?.let { result += it }
+                    }
+                }
+            }
+        }
+
+        return if (result.isEmpty()) parseHtmlTableFromQz() else result
+    }
+
+    private fun parseCell(html: String, day: Int, nodeCount: Int): JwCourse? {
+        val cellDoc = Jsoup.parse(html)
+        val name = try {
+            Jsoup.parse(html.substringBefore("<font").trim()).text()
+        } catch (e: Exception) {
+            html.substringBefore("<font").trim()
+        }
+        if (name.isBlank()) return null
+
+        val teacher = cellDoc.getElementsByAttributeValue("title", "老师").text().trim()
+        val room = cellDoc.getElementsByAttributeValue("title", "教室").text().trim()
+        val weekStr = cellDoc.getElementsByAttributeValue("title", "周次(节次)")
+            .text().substringBefore("(周)")
+
+        val ranges = parseWeekStr(weekStr)
+        val node = nodeCount * 2 - 1
+
+        return JwCourse(
+            name = name,
+            room = room,
+            teacher = teacher,
+            day = day,
+            startNode = node,
+            endNode = node + 1,
+            startWeek = ranges.first().first,
+            endWeek = ranges.first().second,
+            type = ranges.first().third
+        )
+    }
+
+    /** 完全 fallback 到 QZ 解析逻辑 */
+    private fun parseHtmlTableFromQz(): List<JwCourse> {
+        return JwQzParser(source).generateCourseList()
+    }
+}

--- a/app/src/main/java/com/lingion/sleepy/ui/screen/imports/SchoolSelectScreen.kt
+++ b/app/src/main/java/com/lingion/sleepy/ui/screen/imports/SchoolSelectScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.School
+import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -49,6 +50,21 @@ import com.lingion.sleepy.data.jw.JwProtocol
 import com.lingion.sleepy.data.jw.JwSchoolInfo
 import com.lingion.sleepy.ui.theme.SleepyTheme
 import com.lingion.sleepy.util.PinyinMatcher
+
+private fun looksLikeUrl(s: String): Boolean {
+    val t = s.trim()
+    if (t.startsWith("http://") || t.startsWith("https://")) return true
+    // 域名+路径 或 域名:端口
+    if (t.matches(Regex("""[a-zA-Z0-9][-a-zA-Z0-9]{0,62}\.[a-zA-Z]{2,}([/:].*)?"""))) return true
+    // IP:端口
+    if (t.matches(Regex("""\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(:\d+)?(/.*)?"""))) return true
+    return false
+}
+
+private fun normalizeUrl(s: String): String {
+    val t = s.trim()
+    return if (t.startsWith("http://") || t.startsWith("https://")) t else "https://$t"
+}
 
 /**
  * 学校选择页 — 教务直连第一步
@@ -85,6 +101,11 @@ fun SchoolSelectScreen(
         }
     }
 
+    val isUrl = remember(query) { looksLikeUrl(query) }
+    val urlProtocol = remember(query, isUrl) {
+        if (isUrl) viewModel.detectProtocolFromUrl(query) else null
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -114,7 +135,7 @@ fun SchoolSelectScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 8.dp),
-                placeholder = { Text(stringResource(R.string.search_school), color = colors.onSurfaceVariant) },
+                placeholder = { Text(stringResource(R.string.search_school_url), color = colors.onSurfaceVariant) },
                 supportingText = {
                     Text(
                         stringResource(R.string.school_pinyin_hint),
@@ -147,8 +168,27 @@ fun SchoolSelectScreen(
                 }
             }
 
-            if (filtered.isEmpty()) {
+            if (isUrl) {
+                UrlDirectRow(
+                    url = query.trim(),
+                    protocolType = urlProtocol,
+                    onClick = {
+                        val school = JwSchoolInfo(
+                            sortKey = "",
+                            name = "自定义教务",
+                            url = normalizeUrl(query.trim()),
+                            type = urlProtocol,
+                            status = JwSchoolInfo.STATUS_SUPPORTED
+                        )
+                        onSchoolSelected(school)
+                    }
+                )
+            }
+
+            if (filtered.isEmpty() && !isUrl) {
                 EmptyState(schools.isEmpty())
+            } else if (isUrl && filtered.isEmpty()) {
+                // URL detected but no school match — only show URL row (already shown above)
             } else {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
@@ -205,6 +245,61 @@ private fun SchoolRow(school: JwSchoolInfo, onClick: () -> Unit) {
                     style = MaterialTheme.typography.bodySmall,
                     color = colors.onSurfaceVariant,
                     maxLines = 1
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun UrlDirectRow(url: String, protocolType: String?, onClick: () -> Unit) {
+    val colors = SleepyTheme.colors
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 14.dp, horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(colors.primary),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Link,
+                contentDescription = null,
+                tint = colors.onPrimary,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+        Spacer(modifier = Modifier.size(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.url_direct_login),
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+                color = colors.primary
+            )
+            Text(
+                text = url,
+                style = MaterialTheme.typography.bodySmall,
+                color = colors.onSurfaceVariant,
+                maxLines = 1
+            )
+            val protoName = JwProtocol.displayName(if (protocolType.isNullOrBlank()) "" else protocolType)
+            if (protocolType != null) {
+                Text(
+                    text = "${stringResource(R.string.url_detected)} $protoName",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = colors.primary
+                )
+            } else {
+                Text(
+                    text = stringResource(R.string.url_auto_detect),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = colors.onSurfaceVariant
                 )
             }
         }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -238,8 +238,12 @@
     <!-- School Select -->
     <string name="select_school">Select School</string>
     <string name="search_school">Search schools…</string>
+    <string name="search_school_url">Search schools or enter URL…</string>
     <string name="loading">Loading…</string>
     <string name="no_school_found">No matching schools</string>
+    <string name="url_direct_login">Login with this URL</string>
+    <string name="url_detected">Detected:</string>
+    <string name="url_auto_detect">Auto-detect protocol</string>
 
     <!-- Course Detail -->
     <string name="course_week_range">%1$s (Week %2$d-%3$d)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -237,8 +237,12 @@
     <!-- School Select -->
     <string name="select_school">Seleccionar escuela</string>
     <string name="search_school">Buscar escuelas…</string>
+    <string name="search_school_url">Buscar escuelas o introducir URL…</string>
     <string name="loading">Cargando…</string>
     <string name="no_school_found">No se encontraron escuelas</string>
+    <string name="url_direct_login">Iniciar sesión con esta URL</string>
+    <string name="url_detected">Detectado:</string>
+    <string name="url_auto_detect">Autodetectar protocolo</string>
 
     <!-- Course Detail -->
     <string name="course_week_range">%1$s (Semana %2$d-%3$d)</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -237,8 +237,12 @@
     <!-- School Select -->
     <string name="select_school">学校を選択</string>
     <string name="search_school">学校を検索…</string>
+    <string name="search_school_url">学校を検索または URL を入力…</string>
     <string name="loading">読み込み中…</string>
     <string name="no_school_found">一致する学校がありません</string>
+    <string name="url_direct_login">この URL でログイン</string>
+    <string name="url_detected">検出：</string>
+    <string name="url_auto_detect">プロトコルを自動検出</string>
 
     <!-- Course Detail -->
     <string name="course_week_range">%1$s (%2$d-%3$d週)</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -251,8 +251,12 @@
     <!-- School Select -->
     <string name="select_school">选择学校</string>
     <string name="search_school">搜索学校…</string>
+    <string name="search_school_url">搜索学校或输入教务系统 URL…</string>
     <string name="loading">加载中…</string>
     <string name="no_school_found">未找到匹配的学校</string>
+    <string name="url_direct_login">直接用此 URL 登录</string>
+    <string name="url_detected">检测到：</string>
+    <string name="url_auto_detect">自动检测协议类型</string>
 
     <!-- Course Detail -->
     <string name="course_week_range">%1$s (%2$d-%3$d周)</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -237,8 +237,12 @@
     <!-- School Select -->
     <string name="select_school">選擇學校</string>
     <string name="search_school">搜尋學校…</string>
+    <string name="search_school_url">搜尋學校或輸入教務系統 URL…</string>
     <string name="loading">載入中…</string>
     <string name="no_school_found">未找到匹配的學校</string>
+    <string name="url_direct_login">直接用此 URL 登入</string>
+    <string name="url_detected">偵測到：</string>
+    <string name="url_auto_detect">自動偵測協議類型</string>
 
     <!-- Course Detail -->
     <string name="course_week_range">%1$s (%2$d-%3$d週)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -285,8 +285,12 @@
     <!-- School Select -->
     <string name="select_school">选择学校</string>
     <string name="search_school">搜索学校…</string>
+    <string name="search_school_url">搜索学校或输入教务系统 URL…</string>
     <string name="loading">加载中…</string>
     <string name="no_school_found">未找到匹配的学校</string>
+    <string name="url_direct_login">直接用此 URL 登录</string>
+    <string name="url_detected">检测到：</string>
+    <string name="url_auto_detect">自动检测协议类型</string>
 
     <!-- Course Detail -->
     <string name="course_week_range">%1$s (%2$d-%3$d周)</string>


### PR DESCRIPTION
## 新增

### 正方教务解析器 (JwNewZfParser)
- 适配 92 所正方学校（zf/zf_1/zf_new 三协议变体）
- JSON 优先：从页面 `<script>` 提取嵌入课表 JSON（kbxx/tmp_list/xskbcx）
- HTML 兜底：kbcontent class + title 属性解析
- 最终 fallback 到 JwQzParser 保底

### URL 直接登录
- 搜索框检测 URL（域名 / IP:端口 / http(s)://）
- 自动检测协议：jwglxt→zf_new, jwapp→wisedu, urp→urp_new
- 未知协议 → tryAllParsers 逐个尝试取课程数最多结果

## 改动文件
- `JwNewZfParser.kt` 新建
- `JwImportViewModel.kt` ZF→NewZfParser + detectProtocolFromUrl + tryAllParsers
- `SchoolSelectScreen.kt` URL 检测 + UrlDirectRow
- 6 语言 strings.xml

## 版本
1.0.21 → 1.0.22